### PR TITLE
:sparkles: Add all time stats, avoid call openfoodfact, open verif on new tab

### DIFF
--- a/src/features/dashboard/AllTimeProductStats.jsx
+++ b/src/features/dashboard/AllTimeProductStats.jsx
@@ -1,0 +1,182 @@
+import Stat from "./Stat";
+import { useProductCounts } from "./useAllProducts";
+import SpinnerMini from "@/ui/SpinnerMini";
+
+import {
+  HiOutlineDocumentCheck,
+  HiOutlineCheck,
+  HiOutlineChartBar,
+  HiOutlinePaperAirplane,
+  HiOutlineQuestionMarkCircle,
+  HiOutlineClock,
+  HiOutlineCheckCircle,
+  HiOutlineXCircle,
+} from "react-icons/hi2";
+
+import styled from "styled-components";
+
+const StatsGroup = styled.div`
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2.4rem;
+`;
+
+const SubTitle = styled.h3`
+  grid-column: 1 / -1;
+  font-size: 1.6rem;
+  font-weight: 500;
+  color: var(--color-grey-600);
+  margin: 1rem 0 0 0;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--color-grey-300);
+`;
+
+function AllTimeProductStats() {
+  const { 
+    isPending, 
+    error,
+    createdCount,
+    notFoundCount,
+    waitingContactCount,
+    needContactCount,
+    waitingPublishCount,
+    publishedCount,
+    veganCount,
+    nonVeganCount,
+    maybeVeganCount,
+  } = useProductCounts();
+
+  console.log('AllTimeProductStats:', { isPending, error, createdCount, veganCount });
+
+  if (isPending) {
+    return (
+      <>
+        <SubTitle>États produits</SubTitle>
+        <StatsGroup>
+          {Array.from({ length: 5 }, (_, i) => (
+            <Stat
+              key={i}
+              title="Chargement..."
+              color="grey"
+              icon={<SpinnerMini />}
+              value="..."
+            />
+          ))}
+        </StatsGroup>
+        <SubTitle>Statuts produits</SubTitle>
+        <StatsGroup>
+          {Array.from({ length: 4 }, (_, i) => (
+            <Stat
+              key={i + 5}
+              title="Chargement..."
+              color="grey"
+              icon={<SpinnerMini />}
+              value="..."
+            />
+          ))}
+        </StatsGroup>
+      </>
+    );
+  }
+
+  if (error) {
+    console.error('Error in AllTimeProductStats:', error);
+    return (
+      <>
+        <StatsGroup>
+          {Array.from({ length: 5 }, (_, i) => (
+            <Stat
+              key={i}
+              title="Erreur"
+              color="red"
+              icon={<HiOutlineXCircle />}
+              value="Err"
+            />
+          ))}
+        </StatsGroup>
+        <SubTitle>Statuts produits</SubTitle>
+        <StatsGroup>
+          {Array.from({ length: 4 }, (_, i) => (
+            <Stat
+              key={i + 5}
+              title="Erreur"
+              color="red"
+              icon={<HiOutlineXCircle />}
+              value="Err"
+            />
+          ))}
+        </StatsGroup>
+      </>
+    );
+  }
+
+return (
+    <>
+        <SubTitle>États produits</SubTitle>
+        <StatsGroup>
+            <Stat
+                title="À vérifier"
+                color="grey"
+                icon={<HiOutlineDocumentCheck />}
+                value={createdCount}
+            />
+            <Stat
+                title="En attente contact"
+                color="blue"
+                icon={<HiOutlineClock />}
+                value={waitingContactCount}
+            />
+            <Stat
+                title="À contacter"
+                color="yellow"
+                icon={<HiOutlinePaperAirplane />}
+                value={needContactCount}
+            />
+            <Stat
+                title="À publier"
+                color="indigo"
+                icon={<HiOutlineCheck />}
+                value={waitingPublishCount}
+            />
+            <Stat
+                title="Publiés"
+                color="green"
+                icon={<HiOutlineCheck />}
+                value={publishedCount}
+            />
+        </StatsGroup>
+        
+        <SubTitle>Statuts produits</SubTitle>
+        
+        <StatsGroup>
+            <Stat
+                title="VEGAN"
+                color="green"
+                icon={<HiOutlineCheckCircle />}
+                value={veganCount}
+            />
+            <Stat
+                title="MAYBE VEGAN"
+                color="yellow"
+                icon={<HiOutlineCheckCircle />}
+                value={maybeVeganCount}
+            />
+            <Stat
+                title="NON VEGAN"
+                color="red"
+                icon={<HiOutlineXCircle />}
+                value={nonVeganCount}
+            />
+            <Stat
+                title="Inconnu"
+                color="silver"
+                icon={<HiOutlineQuestionMarkCircle />}
+                value={notFoundCount}
+            />
+        </StatsGroup>
+    </>
+);
+}
+
+export default AllTimeProductStats;

--- a/src/features/dashboard/DashboardLayout.jsx
+++ b/src/features/dashboard/DashboardLayout.jsx
@@ -3,6 +3,7 @@ import { useCurrentMonthProducts } from "./useCurrentMonthProducts";
 import Spinner from "@/ui/Spinner";
 
 import ProductStats from "./ProductStats";
+import AllTimeProductStats from "./AllTimeProductStats";
 import ProductsAreaChart from "./ProductsAreaChart";
 import ProductStatesPieChart from "./ProductStatesPieChart";
 import ProductStatusesPieChart from "./ProductStatusesPieChart";
@@ -12,8 +13,27 @@ import styled from "styled-components";
 const StyledDashboardLayout = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
-  grid-template-rows: auto 34rem auto;
   gap: 2.4rem;
+`;
+
+const CurrentMonthSection = styled.div`
+  grid-column: 1 / -1;
+  display: contents;
+`;
+
+const AllTimeSection = styled.div`
+  grid-column: 1 / -1;
+  display: contents;
+`;
+
+const SectionTitle = styled.h2`
+  grid-column: 1 / -1;
+  font-size: 2.4rem;
+  font-weight: 600;
+  color: var(--color-grey-700);
+  margin: 0;
+  padding: 1.6rem 0;
+  border-bottom: 1px solid var(--color-grey-200);
 `;
 
 function DashboardLayout() {
@@ -23,13 +43,24 @@ function DashboardLayout() {
 
   return (
     <StyledDashboardLayout>
-      <ProductStats products={products} />
+      <CurrentMonthSection>
+        <SectionTitle>Statistiques du mois actuel (100 derniers produits)</SectionTitle>
+        
+        <ProductStats products={products} />
 
-      <ProductStatesPieChart products={products} />
+        <ProductStatesPieChart products={products} />
 
-      <ProductStatusesPieChart products={products} />
+        <ProductStatusesPieChart products={products} />
 
-      <ProductsAreaChart products={products} />
+        <ProductsAreaChart products={products} />
+      </CurrentMonthSection>
+
+      <AllTimeSection>
+        <SectionTitle>Statistiques tous temps</SectionTitle>
+
+        <AllTimeProductStats />
+      </AllTimeSection>
+
     </StyledDashboardLayout>
   );
 }

--- a/src/features/dashboard/useAllProductStatusCounts.js
+++ b/src/features/dashboard/useAllProductStatusCounts.js
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getSearchProducts } from "@/services/apiProducts";
+import { PRODUCT_STATUSES } from "@/utils/constants";
+
+import { productsKeys } from "@/features/products/queryKeyFactory";
+
+export function useAllProductStatusCounts() {
+  const statusKeys = Object.keys(PRODUCT_STATUSES);
+
+  const queries = statusKeys.map((status) => {
+    return useQuery({
+      queryKey: productsKeys.list(
+        [{ field: "status", value: status }],
+        "created_at-desc",
+        1,
+        1
+      ),
+      queryFn: () =>
+        getSearchProducts({
+          filters: [{ field: "status", value: status }],
+          sortBy: "created_at-desc",
+          page: 1,
+          size: 1,
+        }),
+    });
+  });
+
+  const isPending = queries.some((query) => query.isPending);
+  const error = queries.find((query) => query.error)?.error;
+
+  const statusCounts = statusKeys.reduce((acc, status, index) => {
+    acc[status] = queries[index].data?.count || 0;
+    return acc;
+  }, {});
+
+  return { isPending, error, statusCounts };
+}

--- a/src/features/dashboard/useAllProducts.js
+++ b/src/features/dashboard/useAllProducts.js
@@ -1,0 +1,232 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getSearchProducts } from "@/services/apiProducts";
+
+import { productsKeys } from "@/features/products/queryKeyFactory";
+
+export function useProductCounts() {
+  // Query for CREATED products count
+  const {
+    isPending: isPendingCreated,
+    data: { count: createdCount } = {},
+    error: createdError,
+  } = useQuery({
+    queryKey: productsKeys.list(
+      [{ field: "state", value: "CREATED" }],
+      "created_at-desc",
+      1,
+      1
+    ),
+    queryFn: () =>
+      getSearchProducts({
+        filters: [{ field: "state", value: "CREATED" }],
+        sortBy: "created_at-desc",
+        page: 1,
+        size: 1,
+      }),
+  });
+
+  // Query for NOT_FOUND products count
+  const {
+    isPending: isPendingNotFound,
+    data: { count: notFoundCount } = {},
+    error: notFoundError,
+  } = useQuery({
+    queryKey: productsKeys.list(
+      [{ field: "status", value: "NOT_FOUND" }],
+      "created_at-desc",
+      1,
+      1
+    ),
+    queryFn: () =>
+      getSearchProducts({
+        filters: [{ field: "status", value: "NOT_FOUND" }],
+        sortBy: "created_at-desc",
+        page: 1,
+        size: 1,
+      }),
+  });
+
+  // Query for WAITING_BRAND_REPLY products count
+  const {
+    isPending: isPendingWaitingContact,
+    data: { count: waitingContactCount } = {},
+    error: waitingContactError,
+  } = useQuery({
+    queryKey: productsKeys.list(
+      [{ field: "state", value: "WAITING_BRAND_REPLY" }],
+      "created_at-desc",
+      1,
+      1
+    ),
+    queryFn: () =>
+      getSearchProducts({
+        filters: [{ field: "state", value: "WAITING_BRAND_REPLY" }],
+        sortBy: "created_at-desc",
+        page: 1,
+        size: 1,
+      }),
+  });
+
+  // Query for NEED_CONTACT products count
+  const {
+    isPending: isPendingNeedContact,
+    data: { count: needContactCount } = {},
+    error: needContactError,
+  } = useQuery({
+    queryKey: productsKeys.list(
+      [{ field: "state", value: "NEED_CONTACT" }],
+      "created_at-desc",
+      1,
+      1
+    ),
+    queryFn: () =>
+      getSearchProducts({
+        filters: [{ field: "state", value: "NEED_CONTACT" }],
+        sortBy: "created_at-desc",
+        page: 1,
+        size: 1,
+      }),
+  });
+
+  // Query for WAITING_PUBLISH products count
+  const {
+    isPending: isPendingWaitingPublish,
+    data: { count: waitingPublishCount } = {},
+    error: waitingPublishError,
+  } = useQuery({
+    queryKey: productsKeys.list(
+      [{ field: "state", value: "WAITING_PUBLISH" }],
+      "created_at-desc",
+      1,
+      1
+    ),
+    queryFn: () =>
+      getSearchProducts({
+        filters: [{ field: "state", value: "WAITING_PUBLISH" }],
+        sortBy: "created_at-desc",
+        page: 1,
+        size: 1,
+      }),
+  });
+
+  // Query for PUBLISHED products count
+  const {
+    isPending: isPendingPublished,
+    data: { count: publishedCount } = {},
+    error: publishedError,
+  } = useQuery({
+    queryKey: productsKeys.list(
+      [{ field: "state", value: "PUBLISHED" }],
+      "created_at-desc",
+      1,
+      1
+    ),
+    queryFn: () =>
+      getSearchProducts({
+        filters: [{ field: "state", value: "PUBLISHED" }],
+        sortBy: "created_at-desc",
+        page: 1,
+        size: 1,
+      }),
+  });
+
+  // Query for VEGAN products count
+  const {
+    isPending: isPendingVegan,
+    data: { count: veganCount } = {},
+    error: veganError,
+  } = useQuery({
+    queryKey: productsKeys.list(
+      [{ field: "status", value: "VEGAN" }],
+      "created_at-desc",
+      1,
+      1
+    ),
+    queryFn: () =>
+      getSearchProducts({
+        filters: [{ field: "status", value: "VEGAN" }],
+        sortBy: "created_at-desc",
+        page: 1,
+        size: 1,
+      }),
+  });
+
+  // Query for NON_VEGAN products count
+  const {
+    isPending: isPendingNonVegan,
+    data: { count: nonVeganCount } = {},
+    error: nonVeganError,
+  } = useQuery({
+    queryKey: productsKeys.list(
+      [{ field: "status", value: "NON_VEGAN" }],
+      "created_at-desc",
+      1,
+      1
+    ),
+    queryFn: () =>
+      getSearchProducts({
+        filters: [{ field: "status", value: "NON_VEGAN" }],
+        sortBy: "created_at-desc",
+        page: 1,
+        size: 1,
+      }),
+  });
+
+  // Query for MAYBE_VEGAN products count
+  const {
+    isPending: isPendingMaybeVegan,
+    data: { count: maybeVeganCount } = {},
+    error: maybeVeganError,
+  } = useQuery({
+    queryKey: productsKeys.list(
+      [{ field: "status", value: "MAYBE_VEGAN" }],
+      "created_at-desc",
+      1,
+      1
+    ),
+    queryFn: () =>
+      getSearchProducts({
+        filters: [{ field: "status", value: "MAYBE_VEGAN" }],
+        sortBy: "created_at-desc",
+        page: 1,
+        size: 1,
+      }),
+  });
+
+  const isPending =
+    isPendingCreated ||
+    isPendingNotFound ||
+    isPendingWaitingContact ||
+    isPendingNeedContact ||
+    isPendingWaitingPublish ||
+    isPendingPublished ||
+    isPendingVegan ||
+    isPendingNonVegan ||
+    isPendingMaybeVegan;
+
+  const error =
+    createdError ||
+    notFoundError ||
+    waitingContactError ||
+    needContactError ||
+    waitingPublishError ||
+    publishedError ||
+    veganError ||
+    nonVeganError ||
+    maybeVeganError;
+
+  return {
+    isPending,
+    error,
+    createdCount: createdCount || 0,
+    notFoundCount: notFoundCount || 0,
+    waitingContactCount: waitingContactCount || 0,
+    needContactCount: needContactCount || 0,
+    waitingPublishCount: waitingPublishCount || 0,
+    publishedCount: publishedCount || 0,
+    veganCount: veganCount || 0,
+    nonVeganCount: nonVeganCount || 0,
+    maybeVeganCount: maybeVeganCount || 0,
+  };
+}

--- a/src/features/dashboard/useAllTimeProductStateCounts.js
+++ b/src/features/dashboard/useAllTimeProductStateCounts.js
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getSearchProducts } from "@/services/apiProducts";
+import { PRODUCT_STATES } from "@/utils/constants";
+
+import { productsKeys } from "@/features/products/queryKeyFactory";
+
+export function useAllTimeProductStateCounts() {
+  const stateKeys = Object.keys(PRODUCT_STATES);
+
+  const queries = stateKeys.map((state) => {
+    return useQuery({
+      queryKey: productsKeys.list(
+        [{ field: "state", value: state }],
+        "created_at-desc",
+        1,
+        1
+      ),
+      queryFn: () =>
+        getSearchProducts({
+          filters: [{ field: "state", value: state }],
+          sortBy: "created_at-desc",
+          page: 1,
+          size: 1,
+        }),
+    });
+  });
+
+  const isPending = queries.some((query) => query.isPending);
+  const error = queries.find((query) => query.error)?.error;
+
+  const stateCounts = stateKeys.reduce((acc, state, index) => {
+    acc[state] = queries[index].data?.count || 0;
+    return acc;
+  }, {});
+
+  return { isPending, error, stateCounts };
+}

--- a/src/features/products/ProductTableRow.jsx
+++ b/src/features/products/ProductTableRow.jsx
@@ -95,7 +95,7 @@ function ProductTableRow({ product }) {
                   product.state === "CREATED" && (
                     <Menus.Button
                       icon={<HiDocumentCheck />}
-                      onClick={() => navigate(`/register/${productId}`)}
+                      onClick={() => window.open(`/register/${productId}`, '_blank')}
                     >
                       Vérifier
                     </Menus.Button>

--- a/src/features/products/useOffProduct.js
+++ b/src/features/products/useOffProduct.js
@@ -20,6 +20,9 @@ export function useOffProduct() {
     enabled: !!productCode,
     retry: false,
     staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchOnMount: false,
     meta: {
       errorMessage: `Ean ${productCode} inconnu dans Open Food Facts`,
     },

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -17,7 +17,6 @@ export const USER_ROLES = {
 
 export const PRODUCT_STATES = {
   CREATED: { color: "grey", label: "À vérifier", role: "user" },
-  NOT_FOUND: { color: "silver", label: "Inconnu", role: "contributor" },
   NEED_CONTACT: { color: "yellow", label: "À contacter", role: "contributor" },
   WAITING_BRAND_REPLY: {
     color: "blue",


### PR DESCRIPTION
Hi @ISAsxm ,

I made this to add an all time stats below the current month stats (I also think we need to up the 100 limit for the pagination in the API as 100 last products is not a lot (sometimes its the number of products for a single day or two )).
This allow to have a great overview of the database products states !

<img width="1515" height="846" alt="image" src="https://github.com/user-attachments/assets/93da0784-cfa8-423d-91f6-bf39ea94af3e" />

I also make that the "verify" button on the productS page opens a new tab to make verification easier

And finally, i did something that seem to fix the fact that we were fetching openfoodfact on refocus


I would really appreciate a feedback on this :)
Thank you !