### PR TITLE
:bug: Fix score N/A when 0.0

### DIFF
--- a/src/features/brands/BrandDetail.jsx
+++ b/src/features/brands/BrandDetail.jsx
@@ -151,7 +151,9 @@ function BrandDetail() {
               label="Score éthique :"
               type="horizontal"
             >
-              <Tag type={scoreColor}>{score ? `${score}%` : "N/A"}</Tag>
+              <Tag type={scoreColor}>
+                {score !== null ? `${score}%` : "N/A"}
+              </Tag>
             </DataItem>
           </InfoBox>
         </Section>

--- a/src/features/brands/BrandTableRow.jsx
+++ b/src/features/brands/BrandTableRow.jsx
@@ -44,7 +44,7 @@ function BrandTableRow({ brand }) {
         <span>{formatDistanceFromNow(updated_at)}</span>
       </Stacked>
 
-      <Tag type={getScoresColor(score)}>{score ? `${score}%` : "N/A"}</Tag>
+      <Tag type={getScoresColor(score)}>{score !== null ? `${score}%` : "N/A"}</Tag>
 
       {hasAccess("contributor") && (
         <Modal>


### PR DESCRIPTION
All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ISAsxm/321vegan-tool/pulls) for the same update/change?


Hello @ISAsxm !
This is just a small fix: the brand score was showing as N/A when it was 0.0, since the boolean check score ? evaluated to false in that case.

On the API side, I’ve made two updates:
- The full parent tree is now included when fetching a brand by ID.
- If a brand has a root parent with a score, that score will also apply to its children.
